### PR TITLE
Add link to orbitdb/orbit-db repo

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,12 +13,12 @@ search_omit: true
 <a href="https://www.npmjs.com/package/orbit-db" alt="npm version"><img src="https://badge.fury.io/js/orbit-db.svg" /></a>
 <a href="https://www.npmjs.com/package/orbit-db" alt="node"><img src="https://img.shields.io/node/v/orbit-db.svg" /></a></p>
 
-OrbitDB is a serverless, distributed, peer-to-peer database. OrbitDB uses [IPFS](https://ipfs.io) as its data storage and [IPFS Pubsub](https://github.com/ipfs/go-ipfs/blob/master/core/commands/pubsub.go#L23) to automatically sync databases with peers. It's an eventually consistent database that uses [CRDTs](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) for conflict-free database merges making OrbitDB an excellent choice for decentralized apps (dApps), blockchain applications and offline-first web applications.
+[OrbitDB](https://github.com/orbitdb/orbit-db) is a serverless, distributed, peer-to-peer database. OrbitDB uses [IPFS](https://ipfs.io) as its data storage and [IPFS Pubsub](https://github.com/ipfs/go-ipfs/blob/master/core/commands/pubsub.go#L23) to automatically sync databases with peers. It's an eventually consistent database that uses [CRDTs](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) for conflict-free database merges making OrbitDB an excellent choice for decentralized apps (dApps), blockchain applications and offline-first web applications.
 
 <h2 class="center" id="test">Test it live!</h2>
 
 <p class="center">
-<a class="btn btn-demo" href="https://ipfs.io/ipfs/QmeESXh9wPib8Xz7hdRzHuYLDuEUgkYTSuujZ2phQfvznQ/">Live Demo 1</a> 
+<a class="btn btn-demo" href="https://ipfs.io/ipfs/QmeESXh9wPib8Xz7hdRzHuYLDuEUgkYTSuujZ2phQfvznQ/">Live Demo 1</a>
 <a class="btn btn-demo" href="https://ipfs.io/ipfs/QmasHFRj6unJ3nSmtPn97tWDaQWEZw3W9Eh3gUgZktuZDZ/">Live Demo 2</a>
 <a class="btn btn-demo" href="https://ipfs.io/ipfs/QmTJGHccriUtq3qf3bvAQUcDUHnBbHNJG2x2FYwYUecN43/">P2P TodoMVC App</a>
 </p>


### PR DESCRIPTION
This PR fixes #21.

Adds a missing link to https://github.com/orbitdb/orbit-db.