### PR TITLE
add link to community chats

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -4,7 +4,8 @@ title: Community
 excerpt: ""
 ---
 
-OrbitDB has an active developer community. Your best place to find us is on Gitter TODO.
+OrbitDB has an active developer community. Your best place to find us is on [Gitter](https://gitter.im/orbitdb/Lobby).
+We also have communities on [Matrix](https://riot.im/app/#/room/#orbit-db:matrix.org) and [Discord](https://discord.gg/v3RNE3M). And all of these chats are bridged together!
 
 ## Biweekly Calls
 


### PR DESCRIPTION
this adds a link to the OrbitDB gitter which, from looking at the text, seems like it was in the works anyway.

I made it link to the Lobby channel of OrbitDB as that looked like the best option.